### PR TITLE
dockerignore contains pyprojecttoml

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -26,7 +26,6 @@ dist/
 htmlcov/
 *.md
 !README.md
-!README-SSH.md
 .gitignore
 .pre-commit-config.yaml
 requirements.txt

--- a/.dockerignore
+++ b/.dockerignore
@@ -25,9 +25,9 @@ dist/
 .coverage
 htmlcov/
 *.md
+!README.md
 !README-SSH.md
 .gitignore
 .pre-commit-config.yaml
-pyproject.toml
 requirements.txt
 requirements-dev.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Changed
+- Docker image renamed from `binardat-ssh-enabler` to `binardat-switch-config` throughout all documentation and configuration files
+- Updated `.dockerignore` to include `pyproject.toml` in Docker builds (previously excluded)
+- Updated `.dockerignore` to explicitly include `README.md` in Docker builds
+
 ## [2026.01.28] - 2026-01-28
 
 Initial release of the Binardat Switch Configuration tool.

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ The image comes pre-configured with common defaults:
 - **SSH Port**: 22
 
 ```bash
-docker run --network host ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+docker run --network host ghcr.io/bmcdonough/binardat-switch-config:latest
 ```
 
 ### Custom Credentials
@@ -108,7 +108,7 @@ docker run --network host \
   -e SWITCH_IP=192.168.1.100 \
   -e SWITCH_USERNAME=myadmin \
   -e SWITCH_PASSWORD=mypassword \
-  ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+  ghcr.io/bmcdonough/binardat-switch-config:latest
 ```
 
 ## Documentation
@@ -152,10 +152,10 @@ This project uses calendar versioning (CalVer): `YYYY.MM.DD[.MICRO]`
 
 Multiple tags are available for different use cases:
 
-- **Specific version**: `ghcr.io/bmcdonough/binardat-ssh-enabler:v2026.01.28` (recommended for production)
-- **Latest stable**: `ghcr.io/bmcdonough/binardat-ssh-enabler:latest`
-- **Month alias**: `ghcr.io/bmcdonough/binardat-ssh-enabler:2026.01`
-- **Year alias**: `ghcr.io/bmcdonough/binardat-ssh-enabler:2026`
+- **Specific version**: `ghcr.io/bmcdonough/binardat-switch-config:v2026.01.28` (recommended for production)
+- **Latest stable**: `ghcr.io/bmcdonough/binardat-switch-config:latest`
+- **Month alias**: `ghcr.io/bmcdonough/binardat-switch-config:2026.01`
+- **Year alias**: `ghcr.io/bmcdonough/binardat-switch-config:2026`
 
 **Production recommendation**: Always pin to specific version tag to ensure reproducibility.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.8'
 services:
   ssh-enabler:
     build: .
-    image: binardat-ssh-enabler:latest
+    image: binardat-switch-config:latest
     environment:
       - SWITCH_IP=${SWITCH_IP:-192.168.2.1}
       - SWITCH_USERNAME=${SWITCH_USERNAME:-admin}

--- a/docs/development.md
+++ b/docs/development.md
@@ -136,12 +136,12 @@ If you need to create a release manually:
      --build-arg VERSION="v$VERSION" \
      --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
      --build-arg VCS_REF="$(git rev-parse HEAD)" \
-     -t ghcr.io/bmcdonough/binardat-ssh-enabler:v$VERSION \
-     -t ghcr.io/bmcdonough/binardat-ssh-enabler:latest \
+     -t ghcr.io/bmcdonough/binardat-switch-config:v$VERSION \
+     -t ghcr.io/bmcdonough/binardat-switch-config:latest \
      .
 
-   docker push ghcr.io/bmcdonough/binardat-ssh-enabler:v$VERSION
-   docker push ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+   docker push ghcr.io/bmcdonough/binardat-switch-config:v$VERSION
+   docker push ghcr.io/bmcdonough/binardat-switch-config:latest
    ```
 
 7. **Create GitHub release**:

--- a/docs/docker/quickstart.md
+++ b/docs/docker/quickstart.md
@@ -6,12 +6,12 @@ Enable SSH on your Binardat switch in seconds using Docker.
 
 ```bash
 # Run with default settings (192.168.2.1, admin/admin)
-docker run --network host ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+docker run --network host ghcr.io/bmcdonough/binardat-switch-config:latest
 
 # Or with custom IP
 docker run --network host \
   -e SWITCH_IP=192.168.2.50 \
-  ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+  ghcr.io/bmcdonough/binardat-switch-config:latest
 ```
 
 ## Prerequisites
@@ -34,13 +34,13 @@ Multiple image tags are available for different use cases:
 **Production Recommendation**: Pin to a specific version for reproducibility:
 
 ```bash
-docker run --network host ghcr.io/bmcdonough/binardat-ssh-enabler:v2026.01.28
+docker run --network host ghcr.io/bmcdonough/binardat-switch-config:v2026.01.28
 ```
 
 **Development/Testing**: Use `latest` for automatic updates:
 
 ```bash
-docker run --network host ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+docker run --network host ghcr.io/bmcdonough/binardat-switch-config:latest
 ```
 
 ### Checking Image Version
@@ -48,7 +48,7 @@ docker run --network host ghcr.io/bmcdonough/binardat-ssh-enabler:latest
 To verify which version you're running:
 
 ```bash
-docker inspect ghcr.io/bmcdonough/binardat-ssh-enabler:latest | \
+docker inspect ghcr.io/bmcdonough/binardat-switch-config:latest | \
   jq -r '.[0].Config.Labels."org.opencontainers.image.version"'
 ```
 
@@ -67,7 +67,7 @@ The image comes pre-configured with common defaults:
 Simply run:
 
 ```bash
-docker run --network host ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+docker run --network host ghcr.io/bmcdonough/binardat-switch-config:latest
 ```
 
 ### Custom Switch IP
@@ -77,7 +77,7 @@ If your switch is at a different IP address:
 ```bash
 docker run --network host \
   -e SWITCH_IP=192.168.2.100 \
-  ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+  ghcr.io/bmcdonough/binardat-switch-config:latest
 ```
 
 ### Custom Credentials
@@ -89,7 +89,7 @@ docker run --network host \
   -e SWITCH_IP=192.168.2.50 \
   -e SWITCH_USERNAME=myadmin \
   -e SWITCH_PASSWORD=mypassword \
-  ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+  ghcr.io/bmcdonough/binardat-switch-config:latest
 ```
 
 ### Custom SSH Port
@@ -100,7 +100,7 @@ To enable SSH on a non-standard port:
 docker run --network host \
   -e SWITCH_IP=192.168.2.50 \
   -e SWITCH_SSH_PORT=2222 \
-  ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+  ghcr.io/bmcdonough/binardat-switch-config:latest
 ```
 
 ## Building Locally
@@ -116,10 +116,10 @@ cd binardat-switch-config
 git checkout develop
 
 # Build the image
-docker build -t binardat-ssh-enabler:latest .
+docker build -t binardat-switch-config:latest .
 
 # Run it
-docker run --network host binardat-ssh-enabler:latest
+docker run --network host binardat-switch-config:latest
 ```
 
 ## Using Docker Compose
@@ -131,7 +131,7 @@ version: '3.8'
 
 services:
   ssh-enabler:
-    image: ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+    image: ghcr.io/bmcdonough/binardat-switch-config:latest
     environment:
       - SWITCH_IP=192.168.2.1
       - SWITCH_USERNAME=admin
@@ -169,7 +169,7 @@ SWITCH_SSH_PORT=22
 Run with the environment file:
 
 ```bash
-docker run --network host --env-file .env ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+docker run --network host --env-file .env ghcr.io/bmcdonough/binardat-switch-config:latest
 ```
 
 ## Command-Line Arguments
@@ -177,7 +177,7 @@ docker run --network host --env-file .env ghcr.io/bmcdonough/binardat-ssh-enable
 You can also pass arguments directly (these override environment variables):
 
 ```bash
-docker run --network host ghcr.io/bmcdonough/binardat-ssh-enabler:latest \
+docker run --network host ghcr.io/bmcdonough/binardat-switch-config:latest \
   --switch-ip 192.168.2.100 \
   --username admin \
   --password mypass
@@ -186,7 +186,7 @@ docker run --network host ghcr.io/bmcdonough/binardat-ssh-enabler:latest \
 View all available options:
 
 ```bash
-docker run --rm ghcr.io/bmcdonough/binardat-ssh-enabler:latest --help
+docker run --rm ghcr.io/bmcdonough/binardat-switch-config:latest --help
 ```
 
 ## Verification
@@ -253,7 +253,7 @@ Verify your credentials are correct:
 docker run --network host \
   -e SWITCH_USERNAME=yourusername \
   -e SWITCH_PASSWORD=yourpassword \
-  ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+  ghcr.io/bmcdonough/binardat-switch-config:latest
 ```
 
 ### SSH port not accessible after enablement

--- a/docs/docker/troubleshooting.md
+++ b/docs/docker/troubleshooting.md
@@ -24,27 +24,27 @@ You expected a newer version but an older version is running.
 
 1. **Check current version**:
    ```bash
-   docker inspect ghcr.io/bmcdonough/binardat-ssh-enabler:latest | \
+   docker inspect ghcr.io/bmcdonough/binardat-switch-config:latest | \
      jq -r '.[0].Config.Labels."org.opencontainers.image.version"'
    ```
 
 2. **Force pull latest image**:
    ```bash
-   docker pull ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+   docker pull ghcr.io/bmcdonough/binardat-switch-config:latest
    ```
 
 3. **Remove old images and pull fresh**:
    ```bash
-   # Remove all binardat-ssh-enabler images
-   docker images | grep binardat-ssh-enabler | awk '{print $3}' | xargs docker rmi -f
+   # Remove all binardat-switch-config images
+   docker images | grep binardat-switch-config | awk '{print $3}' | xargs docker rmi -f
 
    # Pull fresh image
-   docker pull ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+   docker pull ghcr.io/bmcdonough/binardat-switch-config:latest
    ```
 
 4. **Use specific version tag** (recommended for production):
    ```bash
-   docker run --network host ghcr.io/bmcdonough/binardat-ssh-enabler:v2026.01.28
+   docker run --network host ghcr.io/bmcdonough/binardat-switch-config:v2026.01.28
    ```
 
 ### Docker Image Cache Issues
@@ -56,19 +56,19 @@ Changes not reflected even after pulling new image.
 
 1. **Check image ID and creation date**:
    ```bash
-   docker images ghcr.io/bmcdonough/binardat-ssh-enabler
+   docker images ghcr.io/bmcdonough/binardat-switch-config
    ```
 
 2. **Prune Docker cache**:
    ```bash
    docker system prune -a
-   docker pull ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+   docker pull ghcr.io/bmcdonough/binardat-switch-config:latest
    ```
 
 3. **Run with `--pull always`**:
    ```bash
    docker run --pull always --network host \
-     ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+     ghcr.io/bmcdonough/binardat-switch-config:latest
    ```
 
 ### Version Mismatch Between Documentation and Image
@@ -80,7 +80,7 @@ Documentation references features not available in your image version.
 
 1. **Check image creation date**:
    ```bash
-   docker inspect ghcr.io/bmcdonough/binardat-ssh-enabler:latest | \
+   docker inspect ghcr.io/bmcdonough/binardat-switch-config:latest | \
      jq -r '.[0].Config.Labels."org.opencontainers.image.created"'
    ```
 
@@ -91,7 +91,7 @@ Documentation references features not available in your image version.
 3. **Pull specific version matching documentation**:
    ```bash
    # Example: Pull version 2026.01.28
-   docker pull ghcr.io/bmcdonough/binardat-ssh-enabler:v2026.01.28
+   docker pull ghcr.io/bmcdonough/binardat-switch-config:v2026.01.28
    ```
 
 ### Unexpected Behavior After Upgrade
@@ -110,7 +110,7 @@ Container behavior changed after pulling `:latest` tag.
 2. **Rollback to previous version**:
    ```bash
    # Use a specific older version
-   docker run --network host ghcr.io/bmcdonough/binardat-ssh-enabler:v2026.01.27
+   docker run --network host ghcr.io/bmcdonough/binardat-switch-config:v2026.01.27
    ```
 
 3. **Pin to specific version** (prevent future auto-updates):
@@ -118,7 +118,7 @@ Container behavior changed after pulling `:latest` tag.
    # In docker-compose.yml
    services:
      ssh-enabler:
-       image: ghcr.io/bmcdonough/binardat-ssh-enabler:v2026.01.28  # Pinned
+       image: ghcr.io/bmcdonough/binardat-switch-config:v2026.01.28  # Pinned
    ```
 
 For more on version management, see [Versioning and Release Process](versioning-and-releases.md).
@@ -138,7 +138,7 @@ Error: Connection refused
 1. **Verify network mode**:
    ```bash
    # Must use --network host
-   docker run --network host ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+   docker run --network host ghcr.io/bmcdonough/binardat-switch-config:latest
    ```
 
 2. **Check switch IP**:
@@ -149,7 +149,7 @@ Error: Connection refused
    # Verify switch is on correct IP
    docker run --network host \
      -e SWITCH_IP=192.168.2.100 \
-     ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+     ghcr.io/bmcdonough/binardat-switch-config:latest
    ```
 
 3. **Verify switch web interface is accessible**:
@@ -197,7 +197,7 @@ Error: Connection refused
    ```bash
    docker run --network host \
      -e TIMEOUT=30 \
-     ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+     ghcr.io/bmcdonough/binardat-switch-config:latest
    ```
 
 2. **Check switch is responding**:
@@ -230,7 +230,7 @@ Error: Connection refused
    # Escape special characters in passwords
    docker run --network host \
      -e SWITCH_PASSWORD='my$ecure!pass' \
-     ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+     ghcr.io/bmcdonough/binardat-switch-config:latest
    ```
 
 3. **Try default credentials**:
@@ -238,7 +238,7 @@ Error: Connection refused
    docker run --network host \
      -e SWITCH_USERNAME=admin \
      -e SWITCH_PASSWORD=admin \
-     ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+     ghcr.io/bmcdonough/binardat-switch-config:latest
    ```
 
 ### Password with Special Characters
@@ -254,19 +254,19 @@ Password not accepted, bash interpretation issues
    SWITCH_PASSWORD=my$pecial!pass@123
    ```
    ```bash
-   docker run --network host --env-file .env ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+   docker run --network host --env-file .env ghcr.io/bmcdonough/binardat-switch-config:latest
    ```
 
 2. **Use single quotes** in command line:
    ```bash
    docker run --network host \
      -e SWITCH_PASSWORD='my$pecial!pass@123' \
-     ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+     ghcr.io/bmcdonough/binardat-switch-config:latest
    ```
 
 3. **Use command-line arguments**:
    ```bash
-   docker run --network host ghcr.io/bmcdonough/binardat-ssh-enabler:latest \
+   docker run --network host ghcr.io/bmcdonough/binardat-switch-config:latest \
      --password 'my$pecial!pass@123'
    ```
 
@@ -312,7 +312,7 @@ Container starts and exits without output
 
 2. **Run with --rm for automatic cleanup**:
    ```bash
-   docker run --rm --network host ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+   docker run --rm --network host ghcr.io/bmcdonough/binardat-switch-config:latest
    ```
 
 3. **Check for conflicting containers**:
@@ -361,19 +361,19 @@ This should not happen with the official image. If you see this:
 
 1. **Use official image**:
    ```bash
-   docker pull ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+   docker pull ghcr.io/bmcdonough/binardat-switch-config:latest
    ```
 
 2. **Check CHROMEDRIVER_PATH**:
    ```bash
    docker run --network host \
      -e CHROMEDRIVER_PATH=/usr/bin/chromedriver \
-     ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+     ghcr.io/bmcdonough/binardat-switch-config:latest
    ```
 
 3. **Verify ChromeDriver in image**:
    ```bash
-   docker run --rm ghcr.io/bmcdonough/binardat-ssh-enabler:latest \
+   docker run --rm ghcr.io/bmcdonough/binardat-switch-config:latest \
      /bin/bash -c "which chromedriver"
    ```
 
@@ -389,7 +389,7 @@ session deleted because of page crash
 
 1. **Increase shared memory** (if not using --network host):
    ```bash
-   docker run --network host --shm-size=2g ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+   docker run --network host --shm-size=2g ghcr.io/bmcdonough/binardat-switch-config:latest
    ```
 
 2. **Verify --no-sandbox flag** (already included in image)
@@ -413,7 +413,7 @@ TimeoutException: Message:
    ```bash
    docker run --network host \
      -e TIMEOUT=30 \
-     ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+     ghcr.io/bmcdonough/binardat-switch-config:latest
    ```
 
 2. **Check switch responsiveness**:
@@ -427,7 +427,7 @@ TimeoutException: Message:
    docker run --network host \
      -e DISPLAY=$DISPLAY \
      -v /tmp/.X11-unix:/tmp/.X11-unix \
-     ghcr.io/bmcdonough/binardat-ssh-enabler:latest \
+     ghcr.io/bmcdonough/binardat-switch-config:latest \
      --show-browser
    ```
 
@@ -544,7 +544,7 @@ Currently, the script outputs detailed progress. For even more detail:
 
 2. **Run with TTY**:
    ```bash
-   docker run -it --network host ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+   docker run -it --network host ghcr.io/bmcdonough/binardat-switch-config:latest
    ```
 
 ### Show Browser for Visual Debugging
@@ -559,7 +559,7 @@ xhost +local:docker
 docker run --network host \
   -e DISPLAY=$DISPLAY \
   -v /tmp/.X11-unix:/tmp/.X11-unix \
-  ghcr.io/bmcdonough/binardat-ssh-enabler:latest \
+  ghcr.io/bmcdonough/binardat-switch-config:latest \
   --show-browser
 
 # Revoke X11 access after
@@ -573,7 +573,7 @@ If you've modified the code to save page source:
 ```bash
 docker run --network host \
   -v $(pwd)/debug:/debug \
-  ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+  ghcr.io/bmcdonough/binardat-switch-config:latest
 ```
 
 ### Interactive Shell in Container
@@ -584,7 +584,7 @@ For advanced debugging:
 # Start container with shell
 docker run -it --network host \
   --entrypoint /bin/bash \
-  ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+  ghcr.io/bmcdonough/binardat-switch-config:latest
 
 # Inside container
 python enable_ssh.py --help
@@ -594,7 +594,7 @@ python enable_ssh.py --switch-ip 192.168.2.1
 ### Test Network Connectivity from Container
 
 ```bash
-docker run -it --network host --entrypoint /bin/bash ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+docker run -it --network host --entrypoint /bin/bash ghcr.io/bmcdonough/binardat-switch-config:latest
 
 # Inside container
 apt-get update && apt-get install -y iputils-ping curl

--- a/docs/docker/usage.md
+++ b/docs/docker/usage.md
@@ -17,7 +17,7 @@ Comprehensive guide for using the Binardat SSH Enabler Docker image.
 
 ### Docker Image Tags
 
-The `binardat-ssh-enabler` image is published with multiple tags to support different use cases:
+The `binardat-switch-config` image is published with multiple tags to support different use cases:
 
 | Tag | Description | Stability | Use Case |
 |-----|-------------|-----------|----------|
@@ -33,10 +33,10 @@ The `binardat-ssh-enabler` image is published with multiple tags to support diff
 
 ```bash
 # Good - Specific version (reproducible)
-docker run --network host ghcr.io/bmcdonough/binardat-ssh-enabler:v2026.01.28
+docker run --network host ghcr.io/bmcdonough/binardat-switch-config:v2026.01.28
 
 # Avoid - Latest tag (can change unexpectedly)
-docker run --network host ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+docker run --network host ghcr.io/bmcdonough/binardat-switch-config:latest
 ```
 
 **Docker Compose with specific version**:
@@ -45,7 +45,7 @@ docker run --network host ghcr.io/bmcdonough/binardat-ssh-enabler:latest
 version: '3.8'
 services:
   ssh-enabler:
-    image: ghcr.io/bmcdonough/binardat-ssh-enabler:v2026.01.28  # Pinned version
+    image: ghcr.io/bmcdonough/binardat-switch-config:v2026.01.28  # Pinned version
     environment:
       - SWITCH_IP=192.168.2.1
     network_mode: host
@@ -57,7 +57,7 @@ For development and testing, using `latest` is acceptable:
 
 ```bash
 # Development - Use latest tag
-docker run --network host ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+docker run --network host ghcr.io/bmcdonough/binardat-switch-config:latest
 ```
 
 ### Version Verification
@@ -66,15 +66,15 @@ Check which version is currently running:
 
 ```bash
 # Check image version label
-docker inspect ghcr.io/bmcdonough/binardat-ssh-enabler:latest | \
+docker inspect ghcr.io/bmcdonough/binardat-switch-config:latest | \
   jq -r '.[0].Config.Labels."org.opencontainers.image.version"'
 
 # Check image creation date
-docker inspect ghcr.io/bmcdonough/binardat-ssh-enabler:latest | \
+docker inspect ghcr.io/bmcdonough/binardat-switch-config:latest | \
   jq -r '.[0].Config.Labels."org.opencontainers.image.created"'
 
 # View all image labels
-docker inspect ghcr.io/bmcdonough/binardat-ssh-enabler:latest | \
+docker inspect ghcr.io/bmcdonough/binardat-switch-config:latest | \
   jq '.[0].Config.Labels'
 ```
 
@@ -84,10 +84,10 @@ To upgrade to a newer version:
 
 ```bash
 # Pull the new version
-docker pull ghcr.io/bmcdonough/binardat-ssh-enabler:v2026.02.15
+docker pull ghcr.io/bmcdonough/binardat-switch-config:v2026.02.15
 
 # Update your docker-compose.yml or run command with new version
-docker run --network host ghcr.io/bmcdonough/binardat-ssh-enabler:v2026.02.15
+docker run --network host ghcr.io/bmcdonough/binardat-switch-config:v2026.02.15
 ```
 
 **Note**: The `:latest` tag updates automatically on pull, so always specify versions explicitly if reproducibility is important.
@@ -103,7 +103,7 @@ The Docker image supports three configuration methods (in priority order):
 Arguments passed to the container override all other configuration:
 
 ```bash
-docker run --network host ghcr.io/bmcdonough/binardat-ssh-enabler:latest \
+docker run --network host ghcr.io/bmcdonough/binardat-switch-config:latest \
   --switch-ip 192.168.2.100 \
   --username admin \
   --password mypassword \
@@ -135,7 +135,7 @@ docker run --network host \
   -e SWITCH_PASSWORD=mypassword \
   -e SWITCH_SSH_PORT=2222 \
   -e TIMEOUT=15 \
-  ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+  ghcr.io/bmcdonough/binardat-switch-config:latest
 ```
 
 Environment variables:
@@ -181,7 +181,7 @@ TIMEOUT=15
 Run with the environment file:
 
 ```bash
-docker run --network host --env-file .env ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+docker run --network host --env-file .env ghcr.io/bmcdonough/binardat-switch-config:latest
 ```
 
 **Security tip**: Always restrict environment file permissions:
@@ -206,7 +206,7 @@ docker service create \
   --secret switch_username \
   --secret switch_password \
   --network host \
-  ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+  ghcr.io/bmcdonough/binardat-switch-config:latest
 ```
 
 ### Interactive Configuration
@@ -214,7 +214,7 @@ docker service create \
 Get help on available options:
 
 ```bash
-docker run --rm ghcr.io/bmcdonough/binardat-ssh-enabler:latest --help
+docker run --rm ghcr.io/bmcdonough/binardat-switch-config:latest --help
 ```
 
 ## Docker Networking
@@ -225,12 +225,12 @@ The container must access switches on your local network. Docker's default bridg
 
 **Required**:
 ```bash
-docker run --network host ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+docker run --network host ghcr.io/bmcdonough/binardat-switch-config:latest
 ```
 
 **Will NOT work** (default bridge network):
 ```bash
-docker run ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+docker run ghcr.io/bmcdonough/binardat-switch-config:latest
 # Error: Connection refused
 ```
 
@@ -263,14 +263,14 @@ If your switches are on a different subnet than your Docker host:
 # Bad practice
 docker run --network host \
   -e SWITCH_PASSWORD=SuperSecret123 \
-  ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+  ghcr.io/bmcdonough/binardat-switch-config:latest
 ```
 
 **DO** use environment files with restricted permissions:
 ```bash
 # Good practice
 chmod 600 .env
-docker run --network host --env-file .env ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+docker run --network host --env-file .env ghcr.io/bmcdonough/binardat-switch-config:latest
 ```
 
 **BEST** use Docker secrets in production:
@@ -287,7 +287,7 @@ The image follows security best practices:
 - **No SSH keys stored**: Credentials are runtime-only
 - **Read-only filesystem** compatible:
   ```bash
-  docker run --network host --read-only ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+  docker run --network host --read-only ghcr.io/bmcdonough/binardat-switch-config:latest
   ```
 
 ### Network Security
@@ -319,7 +319,7 @@ while IFS= read -r switch_ip; do
     -e SWITCH_IP="$switch_ip" \
     -e SWITCH_USERNAME=admin \
     -e SWITCH_PASSWORD=admin \
-    ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+    ghcr.io/bmcdonough/binardat-switch-config:latest
 
   echo "Completed: $switch_ip"
   echo "---"
@@ -338,7 +338,7 @@ for switch in "${switches[@]}"; do
   docker run --network host \
     -e SWITCH_IP="$switch" \
     --env-file .env \
-    ghcr.io/bmcdonough/binardat-ssh-enabler:latest &
+    ghcr.io/bmcdonough/binardat-switch-config:latest &
 done
 
 # Wait for all background jobs to complete
@@ -369,7 +369,7 @@ tail -n +2 switches.csv | while IFS=, read -r ip username password port; do
     -e SWITCH_USERNAME="$username" \
     -e SWITCH_PASSWORD="$password" \
     -e SWITCH_SSH_PORT="$port" \
-    ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+    ghcr.io/bmcdonough/binardat-switch-config:latest
 done
 ```
 
@@ -384,7 +384,7 @@ version: '3.8'
 
 services:
   ssh-enabler:
-    image: ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+    image: ghcr.io/bmcdonough/binardat-switch-config:latest
     environment:
       - SWITCH_IP=192.168.2.1
       - SWITCH_USERNAME=admin
@@ -408,7 +408,7 @@ version: '3.8'
 
 services:
   ssh-enabler:
-    image: ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+    image: ghcr.io/bmcdonough/binardat-switch-config:latest
     env_file:
       - .env
     network_mode: host
@@ -431,7 +431,7 @@ version: '3.8'
 
 services:
   switch-1:
-    image: ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+    image: ghcr.io/bmcdonough/binardat-switch-config:latest
     environment:
       - SWITCH_IP=192.168.2.1
       - SWITCH_USERNAME=admin
@@ -439,7 +439,7 @@ services:
     network_mode: host
 
   switch-2:
-    image: ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+    image: ghcr.io/bmcdonough/binardat-switch-config:latest
     environment:
       - SWITCH_IP=192.168.2.2
       - SWITCH_USERNAME=admin
@@ -447,7 +447,7 @@ services:
     network_mode: host
 
   switch-3:
-    image: ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+    image: ghcr.io/bmcdonough/binardat-switch-config:latest
     environment:
       - SWITCH_IP=192.168.2.3
       - SWITCH_USERNAME=admin
@@ -471,7 +471,7 @@ For troubleshooting, show the browser window:
 docker run --network host \
   -e DISPLAY=$DISPLAY \
   -v /tmp/.X11-unix:/tmp/.X11-unix \
-  ghcr.io/bmcdonough/binardat-ssh-enabler:latest \
+  ghcr.io/bmcdonough/binardat-switch-config:latest \
   --show-browser
 ```
 
@@ -485,7 +485,7 @@ Override the default ChromeDriver location:
 docker run --network host \
   -e CHROMEDRIVER_PATH=/custom/path/chromedriver \
   -v /path/to/chromedriver:/custom/path/chromedriver \
-  ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+  ghcr.io/bmcdonough/binardat-switch-config:latest
 ```
 
 ### Increased Timeout for Slow Networks
@@ -495,7 +495,7 @@ For switches on slow or unreliable networks:
 ```bash
 docker run --network host \
   -e TIMEOUT=30 \
-  ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+  ghcr.io/bmcdonough/binardat-switch-config:latest
 ```
 
 ### Skip SSH Verification
@@ -504,7 +504,7 @@ If you don't want to verify SSH port accessibility after enablement:
 
 ```bash
 docker run --network host \
-  ghcr.io/bmcdonough/binardat-ssh-enabler:latest \
+  ghcr.io/bmcdonough/binardat-switch-config:latest \
   --no-verify
 ```
 
@@ -515,7 +515,7 @@ Save container output to a file:
 ```bash
 docker run --network host \
   -e SWITCH_IP=192.168.2.1 \
-  ghcr.io/bmcdonough/binardat-ssh-enabler:latest \
+  ghcr.io/bmcdonough/binardat-switch-config:latest \
   2>&1 | tee ssh-enable.log
 ```
 
@@ -524,7 +524,7 @@ docker run --network host \
 For quick operations:
 
 ```bash
-docker run --rm --network host -e SWITCH_IP=192.168.2.50 ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+docker run --rm --network host -e SWITCH_IP=192.168.2.50 ghcr.io/bmcdonough/binardat-switch-config:latest
 ```
 
 The `--rm` flag automatically removes the container after it exits.
@@ -536,7 +536,7 @@ The `--rm` flag automatically removes the container after it exits.
 Containers automatically exit after SSH enablement:
 
 ```bash
-docker run --rm --network host ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+docker run --rm --network host ghcr.io/bmcdonough/binardat-switch-config:latest
 ```
 
 The `--rm` flag ensures the container is removed after exit.
@@ -561,7 +561,7 @@ docker container prune
 Pull the latest image:
 
 ```bash
-docker pull ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+docker pull ghcr.io/bmcdonough/binardat-switch-config:latest
 ```
 
 ## Exit Codes
@@ -578,7 +578,7 @@ The container returns standard exit codes:
 Use in scripts:
 
 ```bash
-if docker run --network host ghcr.io/bmcdonough/binardat-ssh-enabler:latest; then
+if docker run --network host ghcr.io/bmcdonough/binardat-switch-config:latest; then
   echo "SSH enabled successfully"
 else
   echo "Failed to enable SSH"

--- a/docs/docker/versioning-and-releases.md
+++ b/docs/docker/versioning-and-releases.md
@@ -189,17 +189,17 @@ Each release creates MULTIPLE Docker image tags:
 **For release v2026.01.28**:
 
 ```bash
-ghcr.io/bmcdonough/binardat-ssh-enabler:v2026.01.28   # Specific version
-ghcr.io/bmcdonough/binardat-ssh-enabler:2026.01       # Month alias
-ghcr.io/bmcdonough/binardat-ssh-enabler:2026          # Year alias
-ghcr.io/bmcdonough/binardat-ssh-enabler:latest        # Latest stable
+ghcr.io/bmcdonough/binardat-switch-config:v2026.01.28   # Specific version
+ghcr.io/bmcdonough/binardat-switch-config:2026.01       # Month alias
+ghcr.io/bmcdonough/binardat-switch-config:2026          # Year alias
+ghcr.io/bmcdonough/binardat-switch-config:latest        # Latest stable
 ```
 
 **For pre-release v2026.01.28-rc.1**:
 
 ```bash
-ghcr.io/bmcdonough/binardat-ssh-enabler:v2026.01.28-rc.1  # Specific RC
-ghcr.io/bmcdonough/binardat-ssh-enabler:rc                # Latest RC
+ghcr.io/bmcdonough/binardat-switch-config:v2026.01.28-rc.1  # Specific RC
+ghcr.io/bmcdonough/binardat-switch-config:rc                # Latest RC
 ```
 
 ### Tag Stability Guarantees
@@ -217,17 +217,17 @@ ghcr.io/bmcdonough/binardat-ssh-enabler:rc                # Latest RC
 
 **Production**: Always pin to specific version
 ```bash
-docker run --network host ghcr.io/bmcdonough/binardat-ssh-enabler:v2026.01.28
+docker run --network host ghcr.io/bmcdonough/binardat-switch-config:v2026.01.28
 ```
 
 **Development/Testing**: Use latest or dev
 ```bash
-docker run --network host ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+docker run --network host ghcr.io/bmcdonough/binardat-switch-config:latest
 ```
 
 **Continuous updates**: Use month alias (updates automatically each month)
 ```bash
-docker run --network host ghcr.io/bmcdonough/binardat-ssh-enabler:2026.01
+docker run --network host ghcr.io/bmcdonough/binardat-switch-config:2026.01
 ```
 
 ## Release Process
@@ -498,10 +498,10 @@ docker build \
   --build-arg VERSION="v$VERSION" \
   --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
   --build-arg VCS_REF="$(git rev-parse HEAD)" \
-  --tag ghcr.io/bmcdonough/binardat-ssh-enabler:v$VERSION \
-  --tag ghcr.io/bmcdonough/binardat-ssh-enabler:latest \
-  --tag ghcr.io/bmcdonough/binardat-ssh-enabler:$(echo $VERSION | cut -d. -f1-2) \
-  --tag ghcr.io/bmcdonough/binardat-ssh-enabler:$(echo $VERSION | cut -d. -f1) \
+  --tag ghcr.io/bmcdonough/binardat-switch-config:v$VERSION \
+  --tag ghcr.io/bmcdonough/binardat-switch-config:latest \
+  --tag ghcr.io/bmcdonough/binardat-switch-config:$(echo $VERSION | cut -d. -f1-2) \
+  --tag ghcr.io/bmcdonough/binardat-switch-config:$(echo $VERSION | cut -d. -f1) \
   .
 ```
 
@@ -509,10 +509,10 @@ docker build \
 
 ```bash
 # Test with default settings (use a test switch or dry-run mode)
-docker run --rm --network host ghcr.io/bmcdonough/binardat-ssh-enabler:v$VERSION
+docker run --rm --network host ghcr.io/bmcdonough/binardat-switch-config:v$VERSION
 
 # Verify version labels
-docker inspect ghcr.io/bmcdonough/binardat-ssh-enabler:v$VERSION | \
+docker inspect ghcr.io/bmcdonough/binardat-switch-config:v$VERSION | \
   jq '.[0].Config.Labels'
 ```
 
@@ -524,10 +524,10 @@ docker inspect ghcr.io/bmcdonough/binardat-ssh-enabler:v$VERSION | \
 echo $GITHUB_TOKEN | docker login ghcr.io -u YOUR_GITHUB_USERNAME --password-stdin
 
 # Push all tags
-docker push ghcr.io/bmcdonough/binardat-ssh-enabler:v$VERSION
-docker push ghcr.io/bmcdonough/binardat-ssh-enabler:latest
-docker push ghcr.io/bmcdonough/binardat-ssh-enabler:$(echo $VERSION | cut -d. -f1-2)
-docker push ghcr.io/bmcdonough/binardat-ssh-enabler:$(echo $VERSION | cut -d. -f1)
+docker push ghcr.io/bmcdonough/binardat-switch-config:v$VERSION
+docker push ghcr.io/bmcdonough/binardat-switch-config:latest
+docker push ghcr.io/bmcdonough/binardat-switch-config:$(echo $VERSION | cut -d. -f1-2)
+docker push ghcr.io/bmcdonough/binardat-switch-config:$(echo $VERSION | cut -d. -f1)
 ```
 
 #### Step 13: Create GitHub Release
@@ -691,12 +691,12 @@ docker build \
   --build-arg VERSION="v$VERSION" \
   --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
   --build-arg VCS_REF="$(git rev-parse HEAD)" \
-  --tag ghcr.io/bmcdonough/binardat-ssh-enabler:v$VERSION \
-  --tag ghcr.io/bmcdonough/binardat-ssh-enabler:latest \
+  --tag ghcr.io/bmcdonough/binardat-switch-config:v$VERSION \
+  --tag ghcr.io/bmcdonough/binardat-switch-config:latest \
   .
 
-docker push ghcr.io/bmcdonough/binardat-ssh-enabler:v$VERSION
-docker push ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+docker push ghcr.io/bmcdonough/binardat-switch-config:v$VERSION
+docker push ghcr.io/bmcdonough/binardat-switch-config:latest
 
 # Create GitHub release
 gh release create v$VERSION \
@@ -714,12 +714,12 @@ gh issue comment $ISSUE_NUMBER \
 
 Users can pull the latest image:
 \`\`\`bash
-docker pull ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+docker pull ghcr.io/bmcdonough/binardat-switch-config:latest
 \`\`\`
 
 Or pin to this specific hotfix:
 \`\`\`bash
-docker pull ghcr.io/bmcdonough/binardat-ssh-enabler:v$VERSION
+docker pull ghcr.io/bmcdonough/binardat-switch-config:v$VERSION
 \`\`\`"
 ```
 
@@ -763,14 +763,14 @@ Future implementation should include automated releases via GitHub Actions.
 export GOOD_VERSION="2026.01.27"
 
 # Pull previous version
-docker pull ghcr.io/bmcdonough/binardat-ssh-enabler:v$GOOD_VERSION
+docker pull ghcr.io/bmcdonough/binardat-switch-config:v$GOOD_VERSION
 
 # Re-tag as latest
-docker tag ghcr.io/bmcdonough/binardat-ssh-enabler:v$GOOD_VERSION \
-  ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+docker tag ghcr.io/bmcdonough/binardat-switch-config:v$GOOD_VERSION \
+  ghcr.io/bmcdonough/binardat-switch-config:latest
 
 # Push updated latest tag
-docker push ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+docker push ghcr.io/bmcdonough/binardat-switch-config:latest
 ```
 
 **Note**: This doesn't remove the bad version, but prevents new users from getting it via `latest` tag.
@@ -784,7 +784,7 @@ git tag -d v$BAD_VERSION
 git push origin :refs/tags/v$BAD_VERSION
 
 # Delete bad Docker image tags (requires GitHub package admin access)
-# Via GitHub UI: Packages → binardat-ssh-enabler → Select version → Delete
+# Via GitHub UI: Packages → binardat-switch-config → Select version → Delete
 
 # Create hotfix release with fixes
 export HOTFIX_VERSION="2026.01.28.1"
@@ -858,7 +858,7 @@ Always use the `v` prefix in branch names for releases and hotfixes to match the
 **A**: Inspect the Docker image labels:
 
 ```bash
-docker inspect ghcr.io/bmcdonough/binardat-ssh-enabler:latest | \
+docker inspect ghcr.io/bmcdonough/binardat-switch-config:latest | \
   jq -r '.[0].Config.Labels."org.opencontainers.image.version"'
 ```
 
@@ -882,7 +882,7 @@ cat VERSION
 git describe --tags --abbrev=0
 
 # From Docker image labels
-docker inspect ghcr.io/bmcdonough/binardat-ssh-enabler:latest | \
+docker inspect ghcr.io/bmcdonough/binardat-switch-config:latest | \
   jq -r '.[0].Config.Labels."org.opencontainers.image.version"'
 ```
 
@@ -933,16 +933,16 @@ docker build \
   --build-arg VERSION="v$VERSION" \
   --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
   --build-arg VCS_REF="$(git rev-parse HEAD)" \
-  -t ghcr.io/bmcdonough/binardat-ssh-enabler:v$VERSION \
-  -t ghcr.io/bmcdonough/binardat-ssh-enabler:latest \
+  -t ghcr.io/bmcdonough/binardat-switch-config:v$VERSION \
+  -t ghcr.io/bmcdonough/binardat-switch-config:latest \
   .
 ```
 
 ### Push Docker Image
 
 ```bash
-docker push ghcr.io/bmcdonough/binardat-ssh-enabler:v$VERSION
-docker push ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+docker push ghcr.io/bmcdonough/binardat-switch-config:v$VERSION
+docker push ghcr.io/bmcdonough/binardat-switch-config:latest
 ```
 
 ### Create GitHub Release

--- a/examples/docker-compose.example.yml
+++ b/examples/docker-compose.example.yml
@@ -3,7 +3,7 @@ version: '3.8'
 # Example 1: Single switch with environment variables
 services:
   ssh-enabler:
-    image: ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+    image: ghcr.io/bmcdonough/binardat-switch-config:latest
     environment:
       - SWITCH_IP=${SWITCH_IP:-192.168.2.1}
       - SWITCH_USERNAME=${SWITCH_USERNAME:-admin}
@@ -16,7 +16,7 @@ services:
 #
 # services:
 #   ssh-enabler:
-#     image: ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+#     image: ghcr.io/bmcdonough/binardat-switch-config:latest
 #     env_file:
 #       - .env
 #     network_mode: host
@@ -26,7 +26,7 @@ services:
 #
 # services:
 #   switch-1:
-#     image: ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+#     image: ghcr.io/bmcdonough/binardat-switch-config:latest
 #     environment:
 #       - SWITCH_IP=192.168.2.1
 #       - SWITCH_USERNAME=admin
@@ -34,7 +34,7 @@ services:
 #     network_mode: host
 #
 #   switch-2:
-#     image: ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+#     image: ghcr.io/bmcdonough/binardat-switch-config:latest
 #     environment:
 #       - SWITCH_IP=192.168.2.2
 #       - SWITCH_USERNAME=admin
@@ -42,7 +42,7 @@ services:
 #     network_mode: host
 #
 #   switch-3:
-#     image: ghcr.io/bmcdonough/binardat-ssh-enabler:latest
+#     image: ghcr.io/bmcdonough/binardat-switch-config:latest
 #     environment:
 #       - SWITCH_IP=192.168.2.3
 #       - SWITCH_USERNAME=admin

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -90,15 +90,15 @@ docker build \
   --build-arg VERSION="v$VERSION" \
   --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
   --build-arg VCS_REF="$(git rev-parse HEAD)" \
-  --tag "ghcr.io/bmcdonough/binardat-ssh-enabler:v$VERSION" \
-  --tag "ghcr.io/bmcdonough/binardat-ssh-enabler:latest" \
-  --tag "ghcr.io/bmcdonough/binardat-ssh-enabler:$YEAR_MONTH" \
-  --tag "ghcr.io/bmcdonough/binardat-ssh-enabler:$YEAR" \
+  --tag "ghcr.io/bmcdonough/binardat-switch-config:v$VERSION" \
+  --tag "ghcr.io/bmcdonough/binardat-switch-config:latest" \
+  --tag "ghcr.io/bmcdonough/binardat-switch-config:$YEAR_MONTH" \
+  --tag "ghcr.io/bmcdonough/binardat-switch-config:$YEAR" \
   .
 
 # Verify image labels
 print_info "Verifying image labels..."
-IMAGE_VERSION=$(docker inspect ghcr.io/bmcdonough/binardat-ssh-enabler:v$VERSION | \
+IMAGE_VERSION=$(docker inspect ghcr.io/bmcdonough/binardat-switch-config:v$VERSION | \
   jq -r '.[0].Config.Labels."org.opencontainers.image.version"')
 
 if [ "$IMAGE_VERSION" = "v$VERSION" ]; then
@@ -125,13 +125,13 @@ echo "   ${YELLOW}git push origin main${NC}"
 echo "   ${YELLOW}git push origin v$VERSION${NC}"
 echo ""
 echo "4. Push Docker images to registry:"
-echo "   ${YELLOW}docker push ghcr.io/bmcdonough/binardat-ssh-enabler:v$VERSION${NC}"
-echo "   ${YELLOW}docker push ghcr.io/bmcdonough/binardat-ssh-enabler:latest${NC}"
-echo "   ${YELLOW}docker push ghcr.io/bmcdonough/binardat-ssh-enabler:$YEAR_MONTH${NC}"
-echo "   ${YELLOW}docker push ghcr.io/bmcdonough/binardat-ssh-enabler:$YEAR${NC}"
+echo "   ${YELLOW}docker push ghcr.io/bmcdonough/binardat-switch-config:v$VERSION${NC}"
+echo "   ${YELLOW}docker push ghcr.io/bmcdonough/binardat-switch-config:latest${NC}"
+echo "   ${YELLOW}docker push ghcr.io/bmcdonough/binardat-switch-config:$YEAR_MONTH${NC}"
+echo "   ${YELLOW}docker push ghcr.io/bmcdonough/binardat-switch-config:$YEAR${NC}"
 echo ""
 echo "5. Create GitHub release:"
 echo "   ${YELLOW}gh release create v$VERSION --title \"Release v$VERSION\" --latest${NC}"
 echo ""
 echo "Or push all tags at once:"
-echo "   ${YELLOW}docker push ghcr.io/bmcdonough/binardat-ssh-enabler --all-tags${NC}"
+echo "   ${YELLOW}docker push ghcr.io/bmcdonough/binardat-switch-config --all-tags${NC}"


### PR DESCRIPTION
Closes #7 

### Changed
- Docker image renamed from `binardat-ssh-enabler` to `binardat-switch-config` throughout all documentation and configuration files
- Updated `.dockerignore` to include `pyproject.toml` in Docker builds (previously excluded)
- Updated `.dockerignore` to explicitly include `README.md` in Docker builds
